### PR TITLE
Don't error for non-array branches

### DIFF
--- a/lib/triggerable-branch.js
+++ b/lib/triggerable-branch.js
@@ -1,5 +1,9 @@
+const flatten = (arr) => {
+  return Array.prototype.concat(...arr)
+}
+
 module.exports.isTriggerableBranch = ({ app, context, branch, config }) => {
-  const validBranches = config.branches || [context.payload.repository.default_branch]
+  const validBranches = flatten([config.branches || context.payload.repository.default_branch])
   const relevant = validBranches.indexOf(branch) !== -1
   if (!relevant) {
     app.log(`Ignoring push. ${branch} is not one of: ${validBranches.join(', ')}`)


### PR DESCRIPTION
Fixes `errorvalidBranches.join is not a function` errors, for configs such as the [following](https://github.com/custom-components/information/blob/master/.github/release-drafter.yml):

```yml
branches: dev
template: |
  ## Changes
  $CHANGES
```