### PR TITLE
Fix extracting commit numbers

### DIFF
--- a/lib/commits.js
+++ b/lib/commits.js
@@ -20,7 +20,7 @@ module.exports.findCommits = async ({ app, context, branch, lastRelease }) => {
   }
 }
 
-const extractPullRequestNumber = (commit) => {
+module.exports.extractPullRequestNumber = (commit) => {
   // There are two types of GitHub pull request merges, normal and squashed.
   // Normal ones look like 'Merge pull request #123'
   // Squashed ones look like 'Some changes (#123)'
@@ -42,7 +42,7 @@ module.exports.findPullRequests = ({ app, context, commits }) => {
   }
 
   const pullRequestNumbers = commits
-    .map(extractPullRequestNumber)
+    .map(module.exports.extractPullRequestNumber)
     .filter(number => number)
 
   log({ app, context, message: `Found pull request numbers: ${pullRequestNumbers.join(', ')}` })

--- a/lib/commits.js
+++ b/lib/commits.js
@@ -23,8 +23,8 @@ module.exports.findCommits = async ({ app, context, branch, lastRelease }) => {
 module.exports.extractPullRequestNumber = (commit) => {
   // There are two types of GitHub pull request merges, normal and squashed.
   // Normal ones look like 'Merge pull request #123'
-  // Squashed ones look like 'Some changes (#123)'
-  const match = commit.commit.message.match(/\(#(\d+)\)$|^Merge pull request #(\d+)/)
+  // Squashed ones have multiple lines, first one looks like 'Some changes (#123)'
+  const match = commit.commit.message.split('\n')[0].match(/\(#(\d+)\)$|^Merge pull request #(\d+)/)
   return match && (match[1] || match[2])
 }
 

--- a/test/commits.test.js
+++ b/test/commits.test.js
@@ -1,16 +1,14 @@
-const commits = require('../lib/commits');
+const commits = require('../lib/commits')
 
-
-const mockCommit = message => ({ commit: { message }});
-
+const mockCommit = message => ({ commit: { message } })
 
 describe('extractPullRequestNumber', () => {
   it('extracts from merge commit message', () => {
     expect(
       commits.extractPullRequestNumber(mockCommit(
-        'Merge pull request #37 from JasonEtco/patch-1'))
-      ).toEqual("37");
-  });
+        'Merge pull request #37 from JasonEtco/patch-1')
+      )).toEqual('37')
+  })
 
   it('extracts from squash & merge commit message', () => {
     expect(
@@ -21,7 +19,7 @@ Fixed conditional card state on 1st render (#1537)
 * Fixed conditional card state on 1st render
 
 * Moved method to correct location
-        `.trim()))
-      ).toEqual("1537");
-  });
-});
+        `.trim())
+      )).toEqual('1537')
+  })
+})

--- a/test/commits.test.js
+++ b/test/commits.test.js
@@ -1,0 +1,21 @@
+const commits = require('../lib/commits');
+
+
+const mockCommit = message => ({ commit: { message }});
+
+
+describe('extractPullRequestNumber', () => {
+  it('extracts from merge commit message', () => {
+    expect(
+      commits.extractPullRequestNumber(mockCommit(
+        'Merge pull request #37 from JasonEtco/patch-1'))
+      ).toEqual("37");
+  });
+
+  it('extracts from squash & merge commit message', () => {
+    expect(
+      commits.extractPullRequestNumber(mockCommit(
+        'Fixed conditional card state on 1st render (#1537)'))
+      ).toEqual("1537");
+  });
+});

--- a/test/commits.test.js
+++ b/test/commits.test.js
@@ -15,7 +15,13 @@ describe('extractPullRequestNumber', () => {
   it('extracts from squash & merge commit message', () => {
     expect(
       commits.extractPullRequestNumber(mockCommit(
-        'Fixed conditional card state on 1st render (#1537)'))
+        `
+Fixed conditional card state on 1st render (#1537)
+
+* Fixed conditional card state on 1st render
+
+* Moved method to correct location
+        `.trim()))
       ).toEqual("1537");
   });
 });


### PR DESCRIPTION
When a PR is squashed and merged, the commit message will contain multiple lines:

```
<PR TITLE> (#<PR NUMBER>)

<FIRST COMMIT MESSAGE>

<SECOND COMMIT MESSAGE>

etc
```

When we were extracting PR numbers, we were matching against a commit message ending in ` (#1234)`. However, we should have looked at the first line of a commit message ending in that.

Fixes #29