### PR TITLE
Add a $CONTRIBUTORS template variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ You can use any of the following variables in your `template`:
 |Variable|Description|
 |-|-|
 |`$CHANGES`|The markdown list of pull requests that have been merged.|
+|`$CONTRIBUTORS`|A comma separated list of contributors to this release (pull request authors, commit authors, and commit committers).|
 |`$PREVIOUS_TAG`|The previous releases’s tag.|
 
 ## Change Template variables

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = app => {
     const { draftRelease, lastRelease } = await findReleases({ app, context })
     const commits = await findCommits({ app, context, branch, lastRelease })
     const mergedPullRequests = await findPullRequests({ app, context, commits })
-    const body = generateReleaseBody({ config, lastRelease, mergedPullRequests })
+    const body = generateReleaseBody({ commits, config, lastRelease, mergedPullRequests })
 
     if (!draftRelease) {
       log({ app, context, message: 'Creating new draft release' })

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -41,7 +41,24 @@ module.exports.findReleases = async ({ app, context }) => {
   return { draftRelease, lastRelease }
 }
 
-module.exports.generateReleaseBody = ({ config, lastRelease, mergedPullRequests }) => {
+const contributorsSentence = ({ commits, pullRequests }) => {
+  const logins = new Set()
+
+  commits.forEach((commit) => {
+    logins.add(commit.committer.login)
+    logins.add(commit.author.login)
+  })
+
+  pullRequests.forEach((pullRequest) => {
+    logins.add(pullRequest.user.login)
+  })
+
+  const loginStrings = Array.from(logins).map((login) => `@${login}`).sort()
+
+  return loginStrings.slice(0, loginStrings.length - 1).join(', ') + ' and ' + loginStrings.slice(-1)
+}
+
+module.exports.generateReleaseBody = ({ commits, config, lastRelease, mergedPullRequests }) => {
   let body = config.template
 
   if (!lastRelease) {
@@ -60,6 +77,8 @@ module.exports.generateReleaseBody = ({ config, lastRelease, mergedPullRequests 
         .replace('$AUTHOR', pullRequest.user.login)
     )).join('\n'))
   }
+
+  body = body.replace('$CONTRIBUTORS', contributorsSentence({ commits, pullRequests: mergedPullRequests }))
 
   return body
 }

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -42,20 +42,22 @@ module.exports.findReleases = async ({ app, context }) => {
 }
 
 const contributorsSentence = ({ commits, pullRequests }) => {
-  const logins = new Set()
+  const contributors = new Set()
 
   commits.forEach((commit) => {
-    logins.add(commit.committer.login)
-    logins.add(commit.author.login)
+    if (commit.author) {
+      contributors.add(`@${commit.author.login}`)
+    } else {
+      contributors.add(commit.commit.author.name)
+    }
   })
 
   pullRequests.forEach((pullRequest) => {
-    logins.add(pullRequest.user.login)
+    contributors.add(`@${pullRequest.user.login}`)
   })
 
-  const loginStrings = Array.from(logins).map((login) => `@${login}`).sort()
-
-  return loginStrings.slice(0, loginStrings.length - 1).join(', ') + ' and ' + loginStrings.slice(-1)
+  const sortedContributors = Array.from(contributors).sort()
+  return sortedContributors.slice(0, sortedContributors.length - 1).join(', ') + ' and ' + sortedContributors.slice(-1)
 }
 
 module.exports.generateReleaseBody = ({ commits, config, lastRelease, mergedPullRequests }) => {

--- a/test/fixtures/commits.json
+++ b/test/fixtures/commits.json
@@ -246,13 +246,13 @@
     "node_id": "MDY6Q29tbWl0MTM4NzMyNDgxOjE1OWEwNDNlZjI4ZDcwMjNhZGM3ODAwMjk4ZWFkNDQ0YThhNTUwODQ=",
     "commit": {
       "author": {
-        "name": "Tim Lucas",
-        "email": "t@toolmantim.com",
+        "name": "Ada",
+        "email": "a@d.a",
         "date": "2018-06-30T05:05:48Z"
       },
       "committer": {
-        "name": "Tim Lucas",
-        "email": "t@toolmantim.com",
+        "name": "Ada",
+        "email": "a@d.a",
         "date": "2018-06-30T05:05:48Z"
       },
       "message": "More cowbell",
@@ -272,46 +272,8 @@
     "url": "https://api.github.com/repos/toolmantim/release-drafter-test-repository/commits/159a043ef28d7023adc7800298ead444a8a55084",
     "html_url": "https://github.com/toolmantim/release-drafter-test-repository/commit/159a043ef28d7023adc7800298ead444a8a55084",
     "comments_url": "https://api.github.com/repos/toolmantim/release-drafter-test-repository/commits/159a043ef28d7023adc7800298ead444a8a55084/comments",
-    "author": {
-      "login": "toolmantim",
-      "id": 153,
-      "node_id": "MDQ6VXNlcjE1Mw==",
-      "avatar_url": "https://avatars3.githubusercontent.com/u/153?v=4",
-      "gravatar_id": "",
-      "url": "https://api.github.com/users/toolmantim",
-      "html_url": "https://github.com/toolmantim",
-      "followers_url": "https://api.github.com/users/toolmantim/followers",
-      "following_url": "https://api.github.com/users/toolmantim/following{/other_user}",
-      "gists_url": "https://api.github.com/users/toolmantim/gists{/gist_id}",
-      "starred_url": "https://api.github.com/users/toolmantim/starred{/owner}{/repo}",
-      "subscriptions_url": "https://api.github.com/users/toolmantim/subscriptions",
-      "organizations_url": "https://api.github.com/users/toolmantim/orgs",
-      "repos_url": "https://api.github.com/users/toolmantim/repos",
-      "events_url": "https://api.github.com/users/toolmantim/events{/privacy}",
-      "received_events_url": "https://api.github.com/users/toolmantim/received_events",
-      "type": "User",
-      "site_admin": false
-    },
-    "committer": {
-      "login": "toolmantim",
-      "id": 153,
-      "node_id": "MDQ6VXNlcjE1Mw==",
-      "avatar_url": "https://avatars3.githubusercontent.com/u/153?v=4",
-      "gravatar_id": "",
-      "url": "https://api.github.com/users/toolmantim",
-      "html_url": "https://github.com/toolmantim",
-      "followers_url": "https://api.github.com/users/toolmantim/followers",
-      "following_url": "https://api.github.com/users/toolmantim/following{/other_user}",
-      "gists_url": "https://api.github.com/users/toolmantim/gists{/gist_id}",
-      "starred_url": "https://api.github.com/users/toolmantim/starred{/owner}{/repo}",
-      "subscriptions_url": "https://api.github.com/users/toolmantim/subscriptions",
-      "organizations_url": "https://api.github.com/users/toolmantim/orgs",
-      "repos_url": "https://api.github.com/users/toolmantim/repos",
-      "events_url": "https://api.github.com/users/toolmantim/events{/privacy}",
-      "received_events_url": "https://api.github.com/users/toolmantim/received_events",
-      "type": "User",
-      "site_admin": false
-    },
+    "author": null,
+    "committer": null,
     "parents": [
       {
         "sha": "3088733478e16d11a185d48831d923ddfdb0936b",

--- a/test/fixtures/config-with-contributors.yml
+++ b/test/fixtures/config-with-contributors.yml
@@ -1,0 +1,1 @@
+template: "A big thanks to: $CONTRIBUTORS"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -185,7 +185,7 @@ Previous tag: ''
 
           expect(github.repos.createRelease).toBeCalledWith(
             expect.objectContaining({
-              body: `A big thanks to: @another-user, @toolmantim and @web-flow`,
+              body: `A big thanks to: @another-user, @toolmantim and Ada`,
               draft: true,
               tag_name: ''
             })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -167,6 +167,31 @@ Previous tag: ''
           )
         })
       })
+
+      describe('with contributors config', () => {
+        it('adds the contributors', async () => {
+          github.repos.getContent = fn().mockReturnValueOnce(mockConfig('config-with-contributors.yml'))
+          github.repos.getReleases = fn().mockReturnValueOnce(Promise.resolve({ data: [ require('./fixtures/release') ] }))
+          github.repos.compareCommits = fn().mockReturnValueOnce(Promise.resolve({ data: {
+            commits: require('./fixtures/commits')
+          } }))
+          github.pullRequests.get = fn()
+            .mockReturnValueOnce(Promise.resolve(require('./fixtures/pull-request-1')))
+            .mockReturnValueOnce(Promise.resolve(require('./fixtures/pull-request-2')))
+
+          github.repos.createRelease = fn()
+
+          await app.receive({ name: 'push', payload: require('./fixtures/push') })
+
+          expect(github.repos.createRelease).toBeCalledWith(
+            expect.objectContaining({
+              body: `A big thanks to: @another-user, @toolmantim and @web-flow`,
+              draft: true,
+              tag_name: ''
+            })
+          )
+        })
+      })
     })
 
     describe('with no changes since the last release', () => {


### PR DESCRIPTION
This adds a `$CONTRIBUTORS` template variable, which is a comma separated list of GitHub usernames from the commit authors, commit commiters, and pull request authors.

For example:

```yml
template: |
  # Contributors
  
  ❤️ A big thanks to $CONTRIBUTORS
```

which would produce:

```md
# Contributors

❤️ A big thanks to @bkeepers, @salmanulfarzy and @toolmantim.
```

Fixes #53 