### PR TITLE
Use the proper repo name in logs

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,6 +1,11 @@
-module.exports = ({ app, context, message }) => {
+module.exports = ({ app, context, message, info }) => {
   const repo = context.payload.repository
-  const prefix = repo ? `${repo.owner.login}/${repo.owner.name}: ` : ''
+  const prefix = repo ? `${repo.full_name}: ` : ''
+  const logString = `${prefix}${message}`
 
-  app.log(`${prefix}${message}`)
+  if (info) {
+    app.log(logString, info)
+  } else {
+    app.log(logString)
+  }
 }


### PR DESCRIPTION
Logs were incorrectly just repeating the org name, instead of org/repo, for example for the following push to `buildkite-plugins/junit-annotate-buildkite-plugin`:

```
2018-10-20T02:10:42.184Z  02:10:41.889Z  INFO probot: buildkite-plugins/buildkite-plugins: Ignoring push. renovate/docker-ruby-2.5 is not one of: master
```

This fixes the logging so it outputs the correct log prefix.