### PR TITLE
Remove bksr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,5 @@
-language: node_js
-node_js:
-  - "10"
 sudo: required
 services:
   - docker
-before_script:
-  # Buildkite step runner
-  - npm install -g bksr
-  # The buildkite agent itself
-  - curl https://download.buildkite.com/agent/stable/latest/buildkite-agent-linux-amd64 > buildkite-agent
-  - chmod +x buildkite-agent
-  - sudo mv buildkite-agent /usr/local/bin/buildkite-agent
 script:
-  # Run all the steps defined in .buildkite/pipeline.yml
-  bksr --all
+  docker-compose run --rm app npm test


### PR DESCRIPTION
Installing the `buildkite-agent` in Travis VM flags it as abuse, so this removes `bksr` usage in favour of just using docker-compose directly.