### PR TITLE
Update probot-config to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "compare-versions": "3.4.0",
     "probot": "7.5.0",
-    "probot-config": "1.0.0",
+    "probot-config": "1.0.1",
     "request": "2.88.0",
     "semver": "5.6.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -35,7 +35,7 @@ describe('release-drafter', () => {
   describe('push', () => {
     describe('without a config', () => {
       it('does nothing', async () => {
-        github.repos.getContent = fn()
+        github.repos.getContents = fn()
           .mockImplementationOnce(() => mockError(404))
           .mockImplementationOnce(() => mockError(404))
 
@@ -48,7 +48,7 @@ describe('release-drafter', () => {
 
     describe('to a non-master branch', () => {
       it('does nothing', async () => {
-        github.repos.getContent = fn().mockReturnValueOnce(
+        github.repos.getContents = fn().mockReturnValueOnce(
           mockConfig('config.yml')
         )
 
@@ -63,7 +63,7 @@ describe('release-drafter', () => {
 
       describe('when configured for that branch', () => {
         it('creates a release draft', async () => {
-          github.repos.getContent = fn().mockReturnValueOnce(
+          github.repos.getContents = fn().mockReturnValueOnce(
             mockConfig('config-non-master-branch.yml')
           )
           github.repos.getReleases = fn().mockReturnValueOnce(
@@ -92,7 +92,7 @@ describe('release-drafter', () => {
 
     describe('with no past releases', () => {
       it('sets $CHANGES based on all commits, and $PREVIOUS_TAG to blank', async () => {
-        github.repos.getContent = fn().mockReturnValueOnce(
+        github.repos.getContents = fn().mockReturnValueOnce(
           mockConfig('config-previous-tag.yml')
         )
         github.repos.getReleases = fn().mockReturnValueOnce(
@@ -129,7 +129,7 @@ Previous tag: ''
 
     describe('with past releases', () => {
       it('creates a new draft listing the changes', async () => {
-        github.repos.getContent = fn().mockReturnValueOnce(
+        github.repos.getContents = fn().mockReturnValueOnce(
           mockConfig('config.yml')
         )
         github.repos.getReleases = fn().mockReturnValueOnce(
@@ -182,7 +182,7 @@ Previous tag: ''
       })
 
       it('makes next versions available as template placeholders', async () => {
-        github.repos.getContent = fn().mockReturnValueOnce(
+        github.repos.getContents = fn().mockReturnValueOnce(
           mockConfig('config-with-next-versioning.yml')
         )
         github.repos.getReleases = fn().mockReturnValueOnce(
@@ -219,7 +219,7 @@ Previous tag: ''
 
       describe('with custom changes-template config', () => {
         it('creates a new draft using the template', async () => {
-          github.repos.getContent = fn().mockReturnValueOnce(
+          github.repos.getContents = fn().mockReturnValueOnce(
             mockConfig('config-with-changes-templates.yml')
           )
           github.repos.getReleases = fn().mockReturnValueOnce(
@@ -260,7 +260,7 @@ Previous tag: ''
 
       describe('with contributors config', () => {
         it('adds the contributors', async () => {
-          github.repos.getContent = fn().mockReturnValueOnce(
+          github.repos.getContents = fn().mockReturnValueOnce(
             mockConfig('config-with-contributors.yml')
           )
           github.repos.getReleases = fn().mockReturnValueOnce(
@@ -301,7 +301,7 @@ Previous tag: ''
 
     describe('with no changes since the last release', () => {
       it('creates a new draft with no changes', async () => {
-        github.repos.getContent = fn().mockReturnValueOnce(
+        github.repos.getContents = fn().mockReturnValueOnce(
           mockConfig('config.yml')
         )
         github.repos.getReleases = fn().mockReturnValueOnce(
@@ -342,7 +342,7 @@ Previous tag: ''
 
       describe('with custom no-changes-template config', () => {
         it('creates a new draft with the template', async () => {
-          github.repos.getContent = fn().mockReturnValueOnce(
+          github.repos.getContents = fn().mockReturnValueOnce(
             mockConfig('config-with-changes-templates.yml')
           )
           github.repos.getReleases = fn().mockReturnValueOnce(
@@ -371,7 +371,7 @@ Previous tag: ''
 
     describe('with an existing draft release', () => {
       it('updates the existing release’s body', async () => {
-        github.repos.getContent = fn().mockReturnValueOnce(
+        github.repos.getContents = fn().mockReturnValueOnce(
           mockConfig('config.yml')
         )
         github.repos.getReleases = fn().mockReturnValueOnce(
@@ -405,7 +405,7 @@ Previous tag: ''
 
     describe('with categories config', () => {
       it('categorizes pull requests', async () => {
-        github.repos.getContent = fn().mockReturnValueOnce(
+        github.repos.getContents = fn().mockReturnValueOnce(
           mockConfig('config-with-categories.yml')
         )
         github.repos.getReleases = fn().mockReturnValueOnce(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4154,10 +4154,10 @@ pretty-format@^24.0.0:
     ansi-regex "^4.0.0"
     ansi-styles "^3.2.0"
 
-probot-config@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/probot-config/-/probot-config-1.0.0.tgz#4da831672fd08dab26fc522b6aee0027095039d0"
-  integrity sha512-5zV1JjvVH0zy67OZcjv36I/sz7AE7gsVSCkn7rHfNw4tndJhVuKDtq0sn78MoPEPazMbqvq5k0WVYz5MM2Ajyg==
+probot-config@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/probot-config/-/probot-config-1.0.1.tgz#8d4f5eae7f0b0777e0386de8c55a173a434c0dad"
+  integrity sha512-xfQ+Fw8KuxSLj9kET/FN4kdgduVDWpibGP/vNueuhq1bmzRosiFbs/XsB3uUjpm+TWdt37TuwAvFOfvAJm7Sig==
   dependencies:
     deepmerge "^2.2.1"
     js-yaml "^3.10.0"


### PR DESCRIPTION
Update probot-config to 1.0.1 which replaces the deprecated `getContent` with `getContents` (ref: https://github.com/octokit/rest.js/releases/tag/v15.18.0#deprecations). This update is required to make Release Drafter compatible with Probot v9.

https://github.com/toolmantim/release-drafter/pull/119 can be closed if this one is merged :)