### PR TITLE
Update deprecated getCommits to listCommits

### DIFF
--- a/lib/commits.js
+++ b/lib/commits.js
@@ -19,7 +19,7 @@ module.exports.findCommits = async ({ app, context, branch, lastRelease }) => {
   } else {
     log({ app, context, message: `Fetching all commits for branch ${branch}` })
     return context.github.paginate(
-      context.github.repos.getCommits(
+      context.github.repos.listCommits(
         context.repo({
           sha: branch,
           per_page: 100

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -98,7 +98,7 @@ describe('release-drafter', () => {
         github.repos.listReleases = fn().mockReturnValueOnce(
           Promise.resolve({ data: [] })
         )
-        github.repos.getCommits = fn().mockReturnValueOnce(
+        github.repos.listCommits = fn().mockReturnValueOnce(
           Promise.resolve({ data: require('./fixtures/commits') })
         )
         github.pullRequests.get = fn()
@@ -348,7 +348,7 @@ Previous tag: ''
           github.repos.listReleases = fn().mockReturnValueOnce(
             Promise.resolve({ data: [] })
           )
-          github.repos.getCommits = fn().mockReturnValueOnce(
+          github.repos.listCommits = fn().mockReturnValueOnce(
             Promise.resolve({ data: [] })
           )
           github.repos.createRelease = fn()
@@ -377,7 +377,7 @@ Previous tag: ''
         github.repos.listReleases = fn().mockReturnValueOnce(
           Promise.resolve({ data: [require('./fixtures/release-draft.json')] })
         )
-        github.repos.getCommits = fn().mockReturnValueOnce(
+        github.repos.listCommits = fn().mockReturnValueOnce(
           Promise.resolve({ data: require('./fixtures/commits') })
         )
         github.pullRequests.get = fn()


### PR DESCRIPTION
I missed the deprecated `getCommits` in #143. 