### PR TITLE
add package lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 coverage
 now.json
 docker-compose-logs
+package-lock.json


### PR DESCRIPTION
prevents anyone from accidentally committing the `package-lock.json` on a yarn project.
See https://github.com/toolmantim/release-drafter/pull/158#discussion_r271242287