### PR TITLE
Add exclude-labels option for ignoring pull requests based on labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You can configure Release Drafter using the following key in your `.github/relea
 | `no-changes-template` | Optional | The template to use for when there’s no changes. Default: `"* No changes"`.                                                                                                                                       |
 | `branches`            | Optional | The branches to listen for configuration updates to `.github/release-drafter.yml` and for merge commits. Useful if you want to test the app on a pull request branch. Default is the repository’s default branch. |
 | `categories`          | Optional | Categorize pull requests using labels. Refer to [Categorize Pull Requests](#categorize-pull-requests) to learn more about this option.                                                                            |
-| `excludes`            | Optional | Exclude pull requests using labels. Refer to [Exclude Pull Requests](#exclude-pull-requests) to learn more about this option.                                                                                     |
+| `exclude-lables`      | Optional | Exclude pull requests using labels. Refer to [Exclude Pull Requests](#exclude-pull-requests) to learn more about this option.                                                                                     |
 
 Release Drafter also supports [Probot Config](https://github.com/probot/probot-config), if you want to store your configuration files in a central repository. This allows you to share configurations between projects, and create a organization-wide configuration file by creating a repository named `.github` with the file `.github/release-drafter.yml`.
 
@@ -129,10 +129,10 @@ Adding such labels to your PRs can be automated by using [PR Labeler](https://gi
 
 ## Exclude Pull Requests
 
-With the `excludes` option you can exclude pull requests from the release notes using labels. For example, append the following to your `.github/release-drafter.yml` file:
+With the `exclude-labels` option you can exclude pull requests from the release notes using labels. For example, append the following to your `.github/release-drafter.yml` file:
 
 ```yml
-excludes:
+exclude-labels:
   - release
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ You can configure Release Drafter using the following key in your `.github/relea
 | `no-changes-template` | Optional | The template to use for when there’s no changes. Default: `"* No changes"`.                                                                                                                                       |
 | `branches`            | Optional | The branches to listen for configuration updates to `.github/release-drafter.yml` and for merge commits. Useful if you want to test the app on a pull request branch. Default is the repository’s default branch. |
 | `categories`          | Optional | Categorize pull requests using labels. Refer to [Categorize Pull Requests](#categorize-pull-requests) to learn more about this option.                                                                            |
+| `excludes`            | Optional | Exclude pull requests using labels. Refer to [Exclude Pull Requests](#exclude-pull-requests) to learn more about this option.                                                                                     |
 
 Release Drafter also supports [Probot Config](https://github.com/probot/probot-config), if you want to store your configuration files in a central repository. This allows you to share configurations between projects, and create a organization-wide configuration file by creating a repository named `.github` with the file `.github/release-drafter.yml`.
 
@@ -125,6 +126,17 @@ Pull requests with the label "feature" or "fix" will now be grouped together:
 <img src="design/screenshot-2.png" alt="Screenshot of generated draft release with categories" width="586" />
 
 Adding such labels to your PRs can be automated by using [PR Labeler](https://github.com/TimonVS/pr-labeler-action) or [Probot Auto Labeler](https://github.com/probot/autolabeler).
+
+## Exclude Pull Requests
+
+With the `excludes` option you can exclude pull requests from the release notes using labels. For example, append the following to your `.github/release-drafter.yml` file:
+
+```yml
+excludes:
+  - release
+```
+
+Pull requests with the label "release" will now be excluded from the release draft.
 
 ## Projects that don't use Semantic Versioning
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ module.exports = app => {
       'change-template': `* $TITLE (#$NUMBER) @$AUTHOR`,
       'no-changes-template': `* No changes`,
       'version-template': `$MAJOR.$MINOR.$PATCH`,
-      categories: []
+      categories: [],
+      excludes: []
     }
     const config = Object.assign(
       defaults,

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = app => {
       'no-changes-template': `* No changes`,
       'version-template': `$MAJOR.$MINOR.$PATCH`,
       categories: [],
-      excludes: []
+      'exclude-labels': []
     }
     const config = Object.assign(
       defaults,

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -90,10 +90,12 @@ const getCategoriesConfig = ({ config }) => {
   return [categoriesConfig, orderedCategories]
 }
 
-const categorizePullRequests = (pullRequests, categories, excludes) => {
+const categorizePullRequests = (pullRequests, categories, excludeLabels) => {
   return pullRequests.reduce(
     (acc, pullRequest) => {
-      if (pullRequest.labels.some(label => excludes.includes(label.name))) {
+      if (
+        pullRequest.labels.some(label => excludeLabels.includes(label.name))
+      ) {
         return acc
       } else if (
         pullRequest.labels.length === 0 ||
@@ -125,7 +127,7 @@ const generateChangeLog = (mergedPullRequests, config) => {
   const categorizedPullRequests = categorizePullRequests(
     mergedPullRequests,
     orderedCategories,
-    config.excludes
+    config['exclude-labels']
   )
   return orderedCategories
     .reduce((acc, category, index) => {

--- a/lib/releases.js
+++ b/lib/releases.js
@@ -90,10 +90,12 @@ const getCategoriesConfig = ({ config }) => {
   return [categoriesConfig, orderedCategories]
 }
 
-const categorizePullRequests = (pullRequests, categories) => {
+const categorizePullRequests = (pullRequests, categories, excludes) => {
   return pullRequests.reduce(
     (acc, pullRequest) => {
-      if (
+      if (pullRequest.labels.some(label => excludes.includes(label.name))) {
+        return acc
+      } else if (
         pullRequest.labels.length === 0 ||
         !pullRequest.labels.some(label => categories.includes(label.name))
       ) {
@@ -122,7 +124,8 @@ const generateChangeLog = (mergedPullRequests, config) => {
   const [categoriesConfig, orderedCategories] = getCategoriesConfig({ config })
   const categorizedPullRequests = categorizePullRequests(
     mergedPullRequests,
-    orderedCategories
+    orderedCategories,
+    config.excludes
   )
   return orderedCategories
     .reduce((acc, category, index) => {

--- a/test/fixtures/config/config-with-exclude-labels.yml
+++ b/test/fixtures/config/config-with-exclude-labels.yml
@@ -7,5 +7,5 @@ categories:
   - label: fix
     title: 🐛 Bug Fixes
 
-excludes:
+exclude-labels:
   - feature

--- a/test/fixtures/config/config-with-excludes.yml
+++ b/test/fixtures/config/config-with-excludes.yml
@@ -1,0 +1,11 @@
+template: |
+  # What's Changed
+
+  $CHANGES
+
+categories:
+  - label: fix
+    title: 🐛 Bug Fixes
+
+excludes:
+  - feature

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -530,9 +530,9 @@ Previous tag: ''
       })
     })
 
-    describe('with excludes config', () => {
+    describe('with exclude-labels config', () => {
       it('excludes pull requests', async () => {
-        getConfigMock('config-with-excludes.yml')
+        getConfigMock('config-with-exclude-labels.yml')
 
         nock('https://api.github.com')
           .get('/repos/toolmantim/release-drafter-test-project/releases')


### PR DESCRIPTION
Adds the ability to exclude PRs from the changelog, based on their labels.

For example:

```yml
template: |
    # What's Changed
  
    $CHANGES
  
  categories:
    - label: fix
      title: 🐛 Bug Fixes
  
  exclude-labels:
    - dep-update
```