### PR TITLE
Update mocks to make them easier to maintain

### DIFF
--- a/test/fixtures/config/config-with-replacers.yml
+++ b/test/fixtures/config/config-with-replacers.yml
@@ -1,6 +1,6 @@
 replacers:
-  - regex: /Fixed a bug \(#(\d+)/g
-    replace: Fixed a bug (#1000
+  - regex: /Add documentation \(#(\d+)/g
+    replace: Add documentation (#1000
 
 template: |
   # What's Changed

--- a/test/fixtures/graphql-commits-merge-commit.json
+++ b/test/fixtures/graphql-commits-merge-commit.json
@@ -4,15 +4,15 @@
       "ref": {
         "target": {
           "history": {
-            "totalCount": 10,
+            "totalCount": 16,
             "pageInfo": {
               "hasNextPage": false,
-              "endCursor": "6cca0e6c6f24abc3f132f455a23c16e2966060d0 9"
+              "endCursor": "00de634cb5f3c0b854eb30b0afe5b1816e372ed3 15"
             },
             "nodes": [
               {
-                "id": "BDY6Q29tbWl0MTc5MjcyNzYyOjZjY2EwZTZjNmYyNGFiYzNmMTMyZjQ1NWEyM2MxNmUyOTY2MDYwZDA=",
-                "message": "Merge pull request #4 from TimonVS/fix/bug\n\nFixed a bug",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjAwZGU2MzRjYjVmM2MwYjg1NGViMzBiMGFmZTViMTgxNmUzNzJlZDM=",
+                "message": "Merge pull request #5 from TimonVS/add-documentation\n\nAdd documentation",
                 "author": {
                   "name": "Timon van Spronsen",
                   "user": {
@@ -22,21 +22,51 @@
                 "associatedPullRequests": {
                   "nodes": [
                     {
-                      "title": "Fixed a bug",
+                      "title": "Add documentation",
+                      "number": 5,
+                      "mergedAt": "2019-04-27T13:12:08Z",
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "skip-changelog"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmQ4NTg3ZmRiMjYzNjM5Zjc2NTYxMjQ2ZDUzN2UwNDE4YTJmODZhZWU=",
+                "message": "Merge pull request #4 from TimonVS/chore/update-dependencies\n\nUpdate dependencies",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Update dependencies",
                       "number": 4,
+                      "mergedAt": "2019-04-27T13:11:55Z",
                       "author": {
                         "login": "TimonVS"
                       },
                       "labels": {
-                        "nodes": [{ "name": "fix" }]
+                        "nodes": []
                       }
                     }
                   ]
                 }
               },
               {
-                "id": "MDY6Q29tbWl0MTc5MjcyNzYyOjZjY2EwZTZjNmYyNGFiYzNmMTMyZjQ1NWEyM2MxNmUyOTY2MDYwZDA=",
-                "message": "Merge pull request #3 from TimonVS/feature/homepage\n\nImplement homepage",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjI1MzQ0MDhmZWI4MzZkYWNjNTFlYzdjMGFmNGYyNDdlN2JlMzlkNzQ=",
+                "message": "Merge pull request #3 from TimonVS/fix/bug-fixes\n\nBug fixes",
                 "author": {
                   "name": "Timon van Spronsen",
                   "user": {
@@ -46,21 +76,26 @@
                 "associatedPullRequests": {
                   "nodes": [
                     {
-                      "title": "Implement homepage",
+                      "title": "Bug fixes",
                       "number": 3,
+                      "mergedAt": "2019-04-27T13:11:47Z",
                       "author": {
                         "login": "TimonVS"
                       },
                       "labels": {
-                        "nodes": [{ "name": "feature" }]
+                        "nodes": [
+                          {
+                            "name": "fix"
+                          }
+                        ]
                       }
                     }
                   ]
                 }
               },
               {
-                "id": "MDY6Q29tbWl0MTc5MjcyNzYyOjcxNDA5MTA4ZTRhNTg4M2VhODFmODljNjE2Y2Y5NGViMTFmN2Y5YWE=",
-                "message": "Merge pull request #2 from TimonVS/chore/prettier\n\nAdd Prettier config",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjQ4ZTkwNTYwNWQ4ODkyNWI1MjJjMmIwMGY2NDZmNzQ0ZmQ5NzZkMjE=",
+                "message": "Merge pull request #2 from TimonVS/feature/big-feature\n\nAdd big feature",
                 "author": {
                   "name": "Timon van Spronsen",
                   "user": {
@@ -70,21 +105,26 @@
                 "associatedPullRequests": {
                   "nodes": [
                     {
-                      "title": "Add Prettier config",
+                      "title": "Add big feature",
                       "number": 2,
+                      "mergedAt": "2019-04-27T13:11:39Z",
                       "author": {
                         "login": "TimonVS"
                       },
                       "labels": {
-                        "nodes": [{ "name": "skip-changelog" }]
+                        "nodes": [
+                          {
+                            "name": "feature"
+                          }
+                        ]
                       }
                     }
                   ]
                 }
               },
               {
-                "id": "MDY6Q29tbWl0MTc5MjcyNzYyOjgwMGViY2MxY2RmY2UxYmZmN2QyYzE1YTM1MzY2YjZkYzU5YTNjMjg=",
-                "message": "Merge pull request #1 from TimonVS/chore/editorconfig\n\nAdd EditorConfig",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjVmNTViZThiOTA2M2IzOWQ5Y2VkYzllNWRkOGZkMDIyMjFiZDMxZjQ=",
+                "message": "Merge pull request #1 from TimonVS/feature/alien-technology\n\n👽 Add alien technology",
                 "author": {
                   "name": "Timon van Spronsen",
                   "user": {
@@ -94,20 +134,162 @@
                 "associatedPullRequests": {
                   "nodes": [
                     {
-                      "title": "Add EditorConfig",
+                      "title": "👽 Add alien technology",
                       "number": 1,
+                      "mergedAt": "2019-04-27T13:11:29Z",
                       "author": {
                         "login": "TimonVS"
                       },
                       "labels": {
-                        "nodes": [{ "name": "skip-changelog" }]
+                        "nodes": [
+                          {
+                            "name": "feature"
+                          }
+                        ]
                       }
                     }
                   ]
                 }
               },
               {
-                "id": "ADY6Q29tbWl0MTc5MjcyNzYyOjhjZDU4ZWNjMzU0ZjdlMTE2YmI5MzBjYTA5NWNjMGU4NDhjZGQ3YjQ=",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjg1ODExZmJkYmE2OTViYjk3ZDc3YTVlMmE5NjNiMzFmNTM4YTgyMjM=",
+                "message": "Fix typo",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Add documentation",
+                      "number": 5,
+                      "mergedAt": "2019-04-27T13:12:08Z",
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "skip-changelog"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmVkM2FmY2QzNmM4MDhlZWIxNWFhZjc0Zjg3MTNiODVkZTA2ZjBhMTk=",
+                "message": "Add documentation",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Add documentation",
+                      "number": 5,
+                      "mergedAt": "2019-04-27T13:12:08Z",
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "skip-changelog"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmQyMTM0MjNmOTBjZjU5Y2YxMmRiNmUwMTIxYjgwNzE1NTE4NGRiNmQ=",
+                "message": "Update Mongoose to 5.5.4",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Update dependencies",
+                      "number": 4,
+                      "mergedAt": "2019-04-27T13:11:55Z",
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "labels": {
+                        "nodes": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmQ5NTJjMjU1MDI5N2E4NTE1MmJlMWM4MjYwYjI1ZmI4OWYyODFkNDk=",
+                "message": "Update Express to 4.16.4",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Update dependencies",
+                      "number": 4,
+                      "mergedAt": "2019-04-27T13:11:55Z",
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "labels": {
+                        "nodes": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjFiYmJiM2FhYWFmMTk3MDYyYmRmMjg2ODhiMDk4NTI0NjcxM2NkMTI=",
+                "message": "Fixed another bug",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Bug fixes",
+                      "number": 3,
+                      "mergedAt": "2019-04-27T13:11:47Z",
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "fix"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjNlOGE5YTc4ODA3MmRiZDcyMmMxZTkzYTU0NzEzYzI5NzEyNjI5MDY=",
                 "message": "Fixed a bug",
                 "author": {
                   "name": "Timon van Spronsen",
@@ -118,45 +300,26 @@
                 "associatedPullRequests": {
                   "nodes": [
                     {
-                      "title": "Fixed a bug",
-                      "number": 4,
-                      "author": {
-                        "login": "TimonVS"
-                      },
-                      "labels": {
-                        "nodes": [{ "name": "fix" }]
-                      }
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "MDY6Q29tbWl0MTc5MjcyNzYyOjhjZDU4ZWNjMzU0ZjdlMTE2YmI5MzBjYTA5NWNjMGU4NDhjZGQ3YjQ=",
-                "message": "Add contact form to homepage",
-                "author": {
-                  "name": "Timon van Spronsen",
-                  "user": {
-                    "login": "TimonVS"
-                  }
-                },
-                "associatedPullRequests": {
-                  "nodes": [
-                    {
-                      "title": "Implement homepage",
+                      "title": "Bug fixes",
                       "number": 3,
+                      "mergedAt": "2019-04-27T13:11:47Z",
                       "author": {
                         "login": "TimonVS"
                       },
                       "labels": {
-                        "nodes": []
+                        "nodes": [
+                          {
+                            "name": "fix"
+                          }
+                        ]
                       }
                     }
                   ]
                 }
               },
               {
-                "id": "MDY6Q29tbWl0MTc5MjcyNzYyOjVkZGQ2YzAxMzlhM2QxN2Y3NmE2ZjQ3YjA1NjFkODVkMjk5NjM4MGE=",
-                "message": "Add styling",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmI0YWZlNDc3YTZlMmU0OWFmYzdhYTU1ZWYwODMyOTU4MWJmODRiNDM=",
+                "message": "Adjust parameters",
                 "author": {
                   "name": "Timon van Spronsen",
                   "user": {
@@ -166,69 +329,26 @@
                 "associatedPullRequests": {
                   "nodes": [
                     {
-                      "title": "Implement homepage",
-                      "number": 3,
-                      "author": {
-                        "login": "TimonVS"
-                      },
-                      "labels": {
-                        "nodes": []
-                      }
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "MDY6Q29tbWl0MTc5MjcyNzYyOmE3M2M0ZGQ0NWJjY2EwODUyNDQ2MmIyYmI2YjU3OTlkOGI1OGU2Yzg=",
-                "message": "Initial version for homepage",
-                "author": {
-                  "name": "Timon van Spronsen",
-                  "user": {
-                    "login": "TimonVS"
-                  }
-                },
-                "associatedPullRequests": {
-                  "nodes": [
-                    {
-                      "title": "Implement homepage",
-                      "number": 3,
-                      "author": {
-                        "login": "TimonVS"
-                      },
-                      "labels": {
-                        "nodes": []
-                      }
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "MDY6Q29tbWl0MTc5MjcyNzYyOmE2OWFlMGU1NWNkYTYwYWQ3N2IzYWI4M2IzZThmMWEwYzE2NzhjMGQ=",
-                "message": "Add Prettier config",
-                "author": {
-                  "name": "Timon van Spronsen",
-                  "user": {
-                    "login": "TimonVS"
-                  }
-                },
-                "associatedPullRequests": {
-                  "nodes": [
-                    {
-                      "title": "Add Prettier config",
+                      "title": "Add big feature",
                       "number": 2,
+                      "mergedAt": "2019-04-27T13:11:39Z",
                       "author": {
                         "login": "TimonVS"
                       },
                       "labels": {
-                        "nodes": []
+                        "nodes": [
+                          {
+                            "name": "feature"
+                          }
+                        ]
                       }
                     }
                   ]
                 }
               },
               {
-                "id": "MDY6Q29tbWl0MTc5MjcyNzYyOmUzN2FmMTFiZDdhZmFlNmMyMzVlM2E3NDEyZjI3ZWZlYzUyODgzYzc=",
-                "message": "Change indent_size to 4",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmQwMWJjZmNjNzczMWRlYzNiOTg2OWY5ZTFkYTYwMjlhYTY2NzcyNDA=",
+                "message": "Add big feature",
                 "author": {
                   "name": "Timon van Spronsen",
                   "user": {
@@ -238,21 +358,26 @@
                 "associatedPullRequests": {
                   "nodes": [
                     {
-                      "title": "Add EditorConfig",
-                      "number": 1,
+                      "title": "Add big feature",
+                      "number": 2,
+                      "mergedAt": "2019-04-27T13:11:39Z",
                       "author": {
                         "login": "TimonVS"
                       },
                       "labels": {
-                        "nodes": []
+                        "nodes": [
+                          {
+                            "name": "feature"
+                          }
+                        ]
                       }
                     }
                   ]
                 }
               },
               {
-                "id": "MDY6Q29tbWl0MTc5MjcyNzYyOmJlZTY2YTNkNzQ0MDZmZmFhYjNkYjgwNDg5MWNkMmUzOTgwZmQzNTQ=",
-                "message": "Add EditorConfig",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjk0ZGViYjMwZTAyYjExNTc1YWQ0YzBmMDNmMWE1ZjdmOTJiMTFiMjg=",
+                "message": "Add alien technology",
                 "author": {
                   "name": "Timon van Spronsen",
                   "user": {
@@ -262,24 +387,42 @@
                 "associatedPullRequests": {
                   "nodes": [
                     {
-                      "title": "Add EditorConfig",
+                      "title": "👽 Add alien technology",
                       "number": 1,
+                      "mergedAt": "2019-04-27T13:11:29Z",
                       "author": {
                         "login": "TimonVS"
                       },
                       "labels": {
-                        "nodes": []
+                        "nodes": [
+                          {
+                            "name": "feature"
+                          }
+                        ]
                       }
                     }
                   ]
                 }
               },
               {
-                "id": "MDY6Q29tbWl0MTc5MjcyNzYyOjhkYTNmYTEzZDJmNTFjNWM0Yjk5NjA3ODE0MmEzZWE2ZmU1NmQ1NjE=",
-                "message": "first commit",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjNhYmJhNTkxOGZmN2QxMmZhYjMyMjA1N2ZiZGMyM2I1MzVlNzZkMDE=",
+                "message": "Add project description to README",
                 "author": {
-                  "name": "Ada",
+                  "name": "Ada Lovelace",
                   "user": null
+                },
+                "associatedPullRequests": {
+                  "nodes": []
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmI5YWI2MGVlNGI4ZjNmYTg0Mjg2NDQ0NjViZGI1YTg4ZDcyZTY1M2E=",
+                "message": "Initial commit",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
                 },
                 "associatedPullRequests": {
                   "nodes": []

--- a/test/fixtures/graphql-commits-rebase-merging.json
+++ b/test/fixtures/graphql-commits-rebase-merging.json
@@ -4,14 +4,151 @@
       "ref": {
         "target": {
           "history": {
-            "totalCount": 7,
+            "totalCount": 11,
             "pageInfo": {
               "hasNextPage": false,
-              "endCursor": "73101a1b42f7c4e557a8a338054babf2d7e47906 6"
+              "endCursor": "ed0a2bec8c895bb908638795c9da64763be75120 10"
             },
             "nodes": [
               {
-                "id": "ADY6Q29tbWl0MTc5MjYzMzk1OjczMTAxYTFiNDJmN2M0ZTU1N2E4YTMzODA1NGJhYmYyZDdlNDc5MDY=",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmVkMGEyYmVjOGM4OTViYjkwODYzODc5NWM5ZGE2NDc2M2JlNzUxMjA=",
+                "message": "Fix typo",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Add documentation",
+                      "number": 10,
+                      "mergedAt": "2019-04-27T13:38:32Z",
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "skip-changelog"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmZhNDQ2NGQ3MTIyNjg1OTY3MDNjNmI0OGNiNTI4NjkzNzE3NzRlYmY=",
+                "message": "Add documentation",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Add documentation",
+                      "number": 10,
+                      "mergedAt": "2019-04-27T13:38:32Z",
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "skip-changelog"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjkxZjkzZTk1YTBhZGRlNzE0MTk4OTc2OWJlMWJhZTVmOWU2ZDQ4MDA=",
+                "message": "Update Mongoose to 5.5.4",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Update dependencies",
+                      "number": 9,
+                      "mergedAt": "2019-04-27T13:38:26Z",
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "labels": {
+                        "nodes": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjk0NjY1ZWQyMWVjN2YwMTU1MzBkMmRhMWM0ODQzMTVlNTg2NmM2NzY=",
+                "message": "Update Express to 4.16.4",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Update dependencies",
+                      "number": 9,
+                      "mergedAt": "2019-04-27T13:38:26Z",
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "labels": {
+                        "nodes": []
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmMyMmY2MjI0OGYzZDAzMWRmMDAxYWRiZWRkNmY0NGZkOGM3YzQyZDY=",
+                "message": "Fixed another bug",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Bug fixes",
+                      "number": 8,
+                      "mergedAt": "2019-04-27T13:38:20Z",
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "fix"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmQ5MDRkYWFmMzFmOGZkN2M4NjI3MzlkYWNlMjM0ZGViNGQ5MTA0ZmE=",
                 "message": "Fixed a bug",
                 "author": {
                   "name": "Timon van Spronsen",
@@ -22,21 +159,26 @@
                 "associatedPullRequests": {
                   "nodes": [
                     {
-                      "title": "Fixed a bug",
-                      "number": 4,
+                      "title": "Bug fixes",
+                      "number": 8,
+                      "mergedAt": "2019-04-27T13:38:20Z",
                       "author": {
                         "login": "TimonVS"
                       },
                       "labels": {
-                        "nodes": [{ "name": "fix" }]
+                        "nodes": [
+                          {
+                            "name": "fix"
+                          }
+                        ]
                       }
                     }
                   ]
                 }
               },
               {
-                "id": "MDY6Q29tbWl0MTc5MjYzMzk1OjczMTAxYTFiNDJmN2M0ZTU1N2E4YTMzODA1NGJhYmYyZDdlNDc5MDY=",
-                "message": "Add contact form to homepage",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjRmMmEwNjkxOTRlYWY5MDAwMWM2ZDg3Y2EwN2RhNjA0ZDM1Zjc0YTA=",
+                "message": "Adjust parameters",
                 "author": {
                   "name": "Timon van Spronsen",
                   "user": {
@@ -46,21 +188,26 @@
                 "associatedPullRequests": {
                   "nodes": [
                     {
-                      "title": "Implement homepage",
-                      "number": 3,
+                      "title": "Add big feature",
+                      "number": 7,
+                      "mergedAt": "2019-04-27T13:38:13Z",
                       "author": {
                         "login": "TimonVS"
                       },
                       "labels": {
-                        "nodes": [{ "name": "feature" }]
+                        "nodes": [
+                          {
+                            "name": "feature"
+                          }
+                        ]
                       }
                     }
                   ]
                 }
               },
               {
-                "id": "MDY6Q29tbWl0MTc5MjYzMzk1OmZjNDFhZjU5MDhmOThlY2NmOTliZmUxZGY5NDFkOGI1YWRmZDkyZDA=",
-                "message": "Add styling",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjJjZjU4MTc2OTZiNTExODRlNzc5MmI4ODczYWI3MTk4ODIwYmU0ZGE=",
+                "message": "Add big feature",
                 "author": {
                   "name": "Timon van Spronsen",
                   "user": {
@@ -70,21 +217,26 @@
                 "associatedPullRequests": {
                   "nodes": [
                     {
-                      "title": "Implement homepage",
-                      "number": 3,
+                      "title": "Add big feature",
+                      "number": 7,
+                      "mergedAt": "2019-04-27T13:38:13Z",
                       "author": {
                         "login": "TimonVS"
                       },
                       "labels": {
-                        "nodes": [{ "name": "feature" }]
+                        "nodes": [
+                          {
+                            "name": "feature"
+                          }
+                        ]
                       }
                     }
                   ]
                 }
               },
               {
-                "id": "MDY6Q29tbWl0MTc5MjYzMzk1OmY0NzRjZmFiYWMyMTQ4Mzg4MjAyOTZjMDU3NTIzMGU0MDYxNjVhZjA=",
-                "message": "Initial version for homepage",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjIzMmM2MjQ5MTRmMzMyZmI2MmMwZDdiYmViYmYwYWE4NGIyYjJhZWU=",
+                "message": "Add alien technology",
                 "author": {
                   "name": "Timon van Spronsen",
                   "user": {
@@ -94,96 +246,42 @@
                 "associatedPullRequests": {
                   "nodes": [
                     {
-                      "title": "Implement homepage",
-                      "number": 3,
+                      "title": "👽 Add alien technology",
+                      "number": 6,
+                      "mergedAt": "2019-04-27T13:37:59Z",
                       "author": {
                         "login": "TimonVS"
                       },
                       "labels": {
-                        "nodes": [{ "name": "feature" }]
+                        "nodes": [
+                          {
+                            "name": "feature"
+                          }
+                        ]
                       }
                     }
                   ]
                 }
               },
               {
-                "id": "MDY6Q29tbWl0MTc5MjYzMzk1OjZhZjZlMjM2NjRlMDc2NTBiNzdkYjIxOGY1YjBkMzcxYWVmN2MyMmM=",
-                "message": "Add Prettier config",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjNhYmJhNTkxOGZmN2QxMmZhYjMyMjA1N2ZiZGMyM2I1MzVlNzZkMDE=",
+                "message": "Add project description to README",
                 "author": {
-                  "name": "Timon van Spronsen",
-                  "user": {
-                    "login": "TimonVS"
-                  }
-                },
-                "associatedPullRequests": {
-                  "nodes": [
-                    {
-                      "title": "Add Prettier config",
-                      "number": 2,
-                      "author": {
-                        "login": "TimonVS"
-                      },
-                      "labels": {
-                        "nodes": []
-                      }
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "MDY6Q29tbWl0MTc5MjYzMzk1OjFmNGM1MTliMmNiNDNhYjIyYTdhNzk0Yjg5NTM2NWJkNDg3NjkyNzY=",
-                "message": "Change indent_size to 4",
-                "author": {
-                  "name": "Timon van Spronsen",
-                  "user": {
-                    "login": "TimonVS"
-                  }
-                },
-                "associatedPullRequests": {
-                  "nodes": [
-                    {
-                      "title": "Add EditorConfig",
-                      "number": 1,
-                      "author": {
-                        "login": "TimonVS"
-                      },
-                      "labels": {
-                        "nodes": []
-                      }
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "MDY6Q29tbWl0MTc5MjYzMzk1OmMzM2U1ZDA0NGQ3MWY5Y2YyMjMzNDhkN2QxNTA4ODk4MTJlMmMzMTI=",
-                "message": "Add EditorConfig",
-                "author": {
-                  "name": "Timon van Spronsen",
-                  "user": {
-                    "login": "TimonVS"
-                  }
-                },
-                "associatedPullRequests": {
-                  "nodes": [
-                    {
-                      "title": "Add EditorConfig",
-                      "number": 1,
-                      "author": {
-                        "login": "TimonVS"
-                      },
-                      "labels": {
-                        "nodes": []
-                      }
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "MDY6Q29tbWl0MTc5MjYzMzk1OjhkYTNmYTEzZDJmNTFjNWM0Yjk5NjA3ODE0MmEzZWE2ZmU1NmQ1NjE=",
-                "message": "first commit",
-                "author": {
-                  "name": "Ada",
+                  "name": "Ada Lovelace",
                   "user": null
+                },
+                "associatedPullRequests": {
+                  "nodes": []
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmI5YWI2MGVlNGI4ZjNmYTg0Mjg2NDQ0NjViZGI1YTg4ZDcyZTY1M2E=",
+                "message": "Initial commit",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
                 },
                 "associatedPullRequests": {
                   "nodes": []

--- a/test/fixtures/graphql-commits-squash.json
+++ b/test/fixtures/graphql-commits-squash.json
@@ -4,15 +4,15 @@
       "ref": {
         "target": {
           "history": {
-            "totalCount": 4,
+            "totalCount": 7,
             "pageInfo": {
               "hasNextPage": false,
-              "endCursor": "3b9d647ea21e859889135d85b02b4f6e58e43104 3"
+              "endCursor": "3f37d85d6f8bc9e456a93600d1648fe81316ac7c 6"
             },
             "nodes": [
               {
-                "id": "ADY6Q29tbWl0MTc5MjczODgyOjNiOWQ2NDdlYTIxZTg1OTg4OTEzNWQ4NWIwMmI0ZjZlNThlNDMxMDQ=",
-                "message": "Fixed a bug (#4)",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjNmMzdkODVkNmY4YmM5ZTQ1NmE5MzYwMGQxNjQ4ZmU4MTMxNmFjN2M=",
+                "message": "Add documentation (#15)\n\n* Add documentation\r\n\r\n* Fix typo",
                 "author": {
                   "name": "Timon van Spronsen",
                   "user": {
@@ -22,21 +22,26 @@
                 "associatedPullRequests": {
                   "nodes": [
                     {
-                      "title": "Fixed a bug",
-                      "number": 4,
+                      "title": "Add documentation",
+                      "number": 15,
+                      "mergedAt": "2019-04-27T13:39:24Z",
                       "author": {
                         "login": "TimonVS"
                       },
                       "labels": {
-                        "nodes": [{ "name": "fix" }]
+                        "nodes": [
+                          {
+                            "name": "skip-changelog"
+                          }
+                        ]
                       }
                     }
                   ]
                 }
               },
               {
-                "id": "MDY6Q29tbWl0MTc5MjczODgyOjNiOWQ2NDdlYTIxZTg1OTg4OTEzNWQ4NWIwMmI0ZjZlNThlNDMxMDQ=",
-                "message": "Implement homepage (#3)\n\n* Initial version for homepage\r\n\r\n* Add styling\r\n\r\n* Add contact form to homepage",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmViMmVjZjc4YjNjZGI0Y2VlMzc2MmZkZmQ0MjY2MmMwNWM3MzQzZTM=",
+                "message": "Update dependencies (#14)\n\n* Update Express to 4.16.4\r\n\r\n* Update Mongoose to 5.5.4",
                 "author": {
                   "name": "Timon van Spronsen",
                   "user": {
@@ -46,32 +51,9 @@
                 "associatedPullRequests": {
                   "nodes": [
                     {
-                      "title": "Implement homepage",
-                      "number": 3,
-                      "author": {
-                        "login": "TimonVS"
-                      },
-                      "labels": {
-                        "nodes": [{ "name": "feature" }]
-                      }
-                    }
-                  ]
-                }
-              },
-              {
-                "id": "MDY6Q29tbWl0MTc5MjczODgyOjZkOWE0MjgxOGIyY2VlZWYxODEzZTNjZDFiOGQ5ZDk1Mjk2NjAzMTE=",
-                "message": "Add Prettier config (#2)",
-                "author": {
-                  "name": "Timon van Spronsen",
-                  "user": {
-                    "login": "TimonVS"
-                  }
-                },
-                "associatedPullRequests": {
-                  "nodes": [
-                    {
-                      "title": "Add Prettier config",
-                      "number": 2,
+                      "title": "Update dependencies",
+                      "number": 14,
+                      "mergedAt": "2019-04-27T13:39:17Z",
                       "author": {
                         "login": "TimonVS"
                       },
@@ -83,8 +65,8 @@
                 }
               },
               {
-                "id": "MDY6Q29tbWl0MTc5MjczODgyOmMxMTI4OGEwZTJiYWNlYTE1YjcxOTUyYWI2MmU1MzhhMjA2YmMwMmU=",
-                "message": "Add EditorConfig (#1)\n\n* Add EditorConfig\r\n\r\n* Change indent_size to 4",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjc5Zjc4ODBmMTU1ZWU3ZGZkZGUxNmVlMTFmYTMwZmFhMDljODhlMjU=",
+                "message": "Bug fixes (#13)\n\n* Fixed a bug\r\n\r\n* Fixed another bug",
                 "author": {
                   "name": "Timon van Spronsen",
                   "user": {
@@ -94,24 +76,100 @@
                 "associatedPullRequests": {
                   "nodes": [
                     {
-                      "title": "Add EditorConfig",
-                      "number": 1,
+                      "title": "Bug fixes",
+                      "number": 13,
+                      "mergedAt": "2019-04-27T13:39:11Z",
                       "author": {
                         "login": "TimonVS"
                       },
                       "labels": {
-                        "nodes": []
+                        "nodes": [
+                          {
+                            "name": "fix"
+                          }
+                        ]
                       }
                     }
                   ]
                 }
               },
               {
-                "id": "MDY6Q29tbWl0MTc5MjczODgyOjhkYTNmYTEzZDJmNTFjNWM0Yjk5NjA3ODE0MmEzZWE2ZmU1NmQ1NjE=",
-                "message": "first commit",
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmUyMTZhODViOGNlMzU2MzRkN2IyMGNlMjU5YmRmZTA4ZjFhMGJiZGI=",
+                "message": "Add big feature (#12)\n\n* Add big feature\r\n\r\n* Adjust parameters",
                 "author": {
-                  "name": "Ada",
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "Add big feature",
+                      "number": 12,
+                      "mergedAt": "2019-04-27T13:39:03Z",
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "feature"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmQzNmM3YmU4OTBlOGEwYzY3NWYyNzUzMDk0YzYyNmQyN2RiOWI5NmM=",
+                "message": "Add alien technology (#11)",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
+                },
+                "associatedPullRequests": {
+                  "nodes": [
+                    {
+                      "title": "👽 Add alien technology",
+                      "number": 11,
+                      "mergedAt": "2019-04-27T13:38:47Z",
+                      "author": {
+                        "login": "TimonVS"
+                      },
+                      "labels": {
+                        "nodes": [
+                          {
+                            "name": "feature"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOjNhYmJhNTkxOGZmN2QxMmZhYjMyMjA1N2ZiZGMyM2I1MzVlNzZkMDE=",
+                "message": "Add project description to README",
+                "author": {
+                  "name": "Ada Lovelace",
                   "user": null
+                },
+                "associatedPullRequests": {
+                  "nodes": []
+                }
+              },
+              {
+                "id": "MDY6Q29tbWl0MTgzNzY2OTUzOmI5YWI2MGVlNGI4ZjNmYTg0Mjg2NDQ0NjViZGI1YTg4ZDcyZTY1M2E=",
+                "message": "Initial commit",
+                "author": {
+                  "name": "Timon van Spronsen",
+                  "user": {
+                    "login": "TimonVS"
+                  }
                 },
                 "associatedPullRequests": {
                   "nodes": []

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -133,10 +133,11 @@ describe('release-drafter', () => {
             body => {
               expect(body).toMatchObject({
                 body: `Changes:
-* Fixed a bug (#4) @TimonVS
-* Implement homepage (#3) @TimonVS
-* Add Prettier config (#2) @TimonVS
-* Add EditorConfig (#1) @TimonVS
+* Add documentation (#5) @TimonVS
+* Update dependencies (#4) @TimonVS
+* Bug fixes (#3) @TimonVS
+* Add big feature (#2) @TimonVS
+* 👽 Add alien technology (#1) @TimonVS
 
 Previous tag: ''
 `,
@@ -186,10 +187,11 @@ Previous tag: ''
               expect(body).toMatchObject({
                 body: `# What's Changed
 
-* Fixed a bug (#4) @TimonVS
-* Implement homepage (#3) @TimonVS
-* Add Prettier config (#2) @TimonVS
-* Add EditorConfig (#1) @TimonVS
+* Add documentation (#5) @TimonVS
+* Update dependencies (#4) @TimonVS
+* Bug fixes (#3) @TimonVS
+* Add big feature (#2) @TimonVS
+* 👽 Add alien technology (#1) @TimonVS
 `,
                 draft: true,
                 tag_name: ''
@@ -266,10 +268,11 @@ Previous tag: ''
               '/repos/toolmantim/release-drafter-test-project/releases',
               body => {
                 expect(body).toMatchObject({
-                  body: `* Change: #4 'Fixed a bug' @TimonVS
-* Change: #3 'Implement homepage' @TimonVS
-* Change: #2 'Add Prettier config' @TimonVS
-* Change: #1 'Add EditorConfig' @TimonVS`,
+                  body: `* Change: #5 'Add documentation' @TimonVS
+* Change: #4 'Update dependencies' @TimonVS
+* Change: #3 'Bug fixes' @TimonVS
+* Change: #2 'Add big feature' @TimonVS
+* Change: #1 '👽 Add alien technology' @TimonVS`,
                   draft: true,
                   tag_name: ''
                 })
@@ -308,7 +311,7 @@ Previous tag: ''
               '/repos/toolmantim/release-drafter-test-project/releases',
               body => {
                 expect(body).toMatchObject({
-                  body: `A big thanks to: @TimonVS and Ada`,
+                  body: `A big thanks to: @TimonVS and Ada Lovelace`,
                   draft: true,
                   tag_name: ''
                 })
@@ -438,10 +441,11 @@ Previous tag: ''
               expect(body).toMatchObject({
                 body: `# What's Changed
 
-* Fixed a bug (#4) @TimonVS
-* Implement homepage (#3) @TimonVS
-* Add Prettier config (#2) @TimonVS
-* Add EditorConfig (#1) @TimonVS
+* Add documentation (#5) @TimonVS
+* Update dependencies (#4) @TimonVS
+* Bug fixes (#3) @TimonVS
+* Add big feature (#2) @TimonVS
+* 👽 Add alien technology (#1) @TimonVS
 `
               })
               return true
@@ -480,16 +484,17 @@ Previous tag: ''
               expect(body).toMatchObject({
                 body: `# What's Changed
 
-* Add Prettier config (#2) @TimonVS
-* Add EditorConfig (#1) @TimonVS
+* Add documentation (#5) @TimonVS
+* Update dependencies (#4) @TimonVS
 
 ## 🚀 Features
 
-* Implement homepage (#3) @TimonVS
+* Add big feature (#2) @TimonVS
+* 👽 Add alien technology (#1) @TimonVS
 
 ## 🐛 Bug Fixes
 
-* Fixed a bug (#4) @TimonVS
+* Bug fixes (#3) @TimonVS
 `,
                 draft: true,
                 tag_name: ''
@@ -530,13 +535,16 @@ Previous tag: ''
               expect(body).toMatchObject({
                 body: `# What's Changed
 
+* Update dependencies (#4) @TimonVS
+
 ## 🚀 Features
 
-* Implement homepage (#3) @TimonVS
+* Add big feature (#2) @TimonVS
+* 👽 Add alien technology (#1) @TimonVS
 
 ## 🐛 Bug Fixes
 
-* Fixed a bug (#4) @TimonVS
+* Bug fixes (#3) @TimonVS
 `,
                 draft: true,
                 tag_name: ''
@@ -692,10 +700,11 @@ Previous tag: ''
                 expect(body).toMatchObject({
                   body: `# What's Changed
 
-* Fixed a bug (#4) @TimonVS
-* Implement homepage (#3) @TimonVS
-* Add Prettier config (#2) @TimonVS
-* Add EditorConfig (#1) @TimonVS
+* Add documentation (#5) @TimonVS
+* Update dependencies (#4) @TimonVS
+* Bug fixes (#3) @TimonVS
+* Add big feature (#2) @TimonVS
+* 👽 Add alien technology (#1) @TimonVS
 `,
                   draft: true,
                   tag_name: ''
@@ -742,10 +751,11 @@ Previous tag: ''
                 expect(body).toMatchObject({
                   body: `# What's Changed
 
-* Fixed a bug (#4) @TimonVS
-* Implement homepage (#3) @TimonVS
-* Add Prettier config (#2) @TimonVS
-* Add EditorConfig (#1) @TimonVS
+* Add documentation (#10) @TimonVS
+* Update dependencies (#9) @TimonVS
+* Bug fixes (#8) @TimonVS
+* Add big feature (#7) @TimonVS
+* 👽 Add alien technology (#6) @TimonVS
 `,
                   draft: true,
                   tag_name: ''
@@ -789,10 +799,11 @@ Previous tag: ''
                 expect(body).toMatchObject({
                   body: `# What's Changed
 
-* Fixed a bug (#4) @TimonVS
-* Implement homepage (#3) @TimonVS
-* Add Prettier config (#2) @TimonVS
-* Add EditorConfig (#1) @TimonVS
+* Add documentation (#15) @TimonVS
+* Update dependencies (#14) @TimonVS
+* Bug fixes (#13) @TimonVS
+* Add big feature (#12) @TimonVS
+* 👽 Add alien technology (#11) @TimonVS
 `,
                   draft: true,
                   tag_name: ''
@@ -876,6 +887,7 @@ Previous tag: ''
         expect.assertions(1)
       })
     })
+
     describe('custom replacers', () => {
       it('replaces a string', async () => {
         getConfigMock('config-with-replacers.yml')
@@ -899,10 +911,11 @@ Previous tag: ''
               expect(body).toMatchObject({
                 body: `# What's Changed
 
-* Fixed a bug (#1000) @TimonVS
-* Implement homepage (#3) @TimonVS
-* Add Prettier config (#2) @TimonVS
-* Add EditorConfig (#1) @TimonVS
+* Add documentation (#1000) @TimonVS
+* Update dependencies (#4) @TimonVS
+* Bug fixes (#3) @TimonVS
+* Add big feature (#2) @TimonVS
+* 👽 Add alien technology (#1) @TimonVS
 `,
                 draft: true,
                 tag_name: ''


### PR DESCRIPTION
I had manually adjusted some of the mocks which makes it difficult to maintain if we want to regenerate the mocks with added fields (e.g. for #188 we need to add the `mergedAt` field). I've now created a repo (https://github.com/TimonVS/release-drafter-test-repo) with three different branches (`merge-commit`, `rebase-merging` and `squash-merging`) which can be used to regenerate mocks if needed.