### PR TITLE
Remove ‘regex’ key from the ‘search’ option

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,11 @@ For example, if your project doesn't use patch version numbers, you can set `ver
 
 ## Replacers
 
-You can search and replace content in the generated changelog body using the `replacers` option. Replacers support searching via regular expressions with the `regex` option, and plain strings with the `search` option. Each replacer is applied in order.
+You can search and replace content in the generated changelog body, using regular expressions, with the `replacers` option. Each replacer is applied in order.
 
 ```yml
 replacers:
-  - regex: '/CVE-(\d{4})-(\d+)/g'
+  - search: '/CVE-(\d{4})-(\d+)/g'
     replace: 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-$1-$2'
   - search: 'myname'
     replace: 'My Name'

--- a/lib/template.js
+++ b/lib/template.js
@@ -27,22 +27,20 @@ const template = (string, obj, customReplacers) => {
   return str
 }
 
+function toRegex(search) {
+  if (search.match(/^\/.+\/[gmixXsuUAJ]*$/)) {
+    return regexParser(search)
+  } else {
+    // plain string
+    return new RegExp(regexEscape(search), 'g')
+  }
+}
+
 function validateReplacers({ app, context, replacers }) {
   return replacers
     .map(replacer => {
       try {
-        if (replacer.regex) {
-          return {
-            search: regexParser(replacer.regex),
-            replace: replacer.replace
-          }
-        } else {
-          // plain string
-          return {
-            search: new RegExp(regexEscape(replacer.search), 'g'),
-            replace: replacer.replace
-          }
-        }
+        return { ...replacer, search: toRegex(replacer.search) }
       } catch (e) {
         log({
           app,

--- a/test/fixtures/config/config-with-replacers.yml
+++ b/test/fixtures/config/config-with-replacers.yml
@@ -1,5 +1,5 @@
 replacers:
-  - regex: /Add documentation \(#(\d+)/g
+  - search: /Add documentation \(#(\d+)/g
     replace: Add documentation (#1000
 
 template: |

--- a/test/template.test.js
+++ b/test/template.test.js
@@ -51,7 +51,7 @@ describe('template', () => {
     const customReplacer = validateReplacers({
       replacers: [
         {
-          regex: '/\\bJENKINS-(\\d+)\\b/g',
+          search: '/\\bJENKINS-(\\d+)\\b/g',
           replace:
             '[https://issues.jenkins-ci.org/browse/JENKINS-$1](JENKINS-$1)'
         }
@@ -71,7 +71,7 @@ describe('template', () => {
     const customReplacer = validateReplacers({
       replacers: [
         {
-          regex: 'JENKINS',
+          search: 'JENKINS',
           replace: 'heyyyyyyy'
         }
       ]
@@ -101,12 +101,12 @@ describe('template', () => {
     const customReplacer = validateReplacers({
       replacers: [
         {
-          regex: '/\\bJENKINS-(\\d+)\\b/g',
+          search: '/\\bJENKINS-(\\d+)\\b/g',
           replace:
             '[https://issues.jenkins-ci.org/browse/JENKINS-$1](JENKINS-$1)'
         },
         {
-          regex:
+          search:
             '/\\[\\[https://issues.jenkins-ci.org/browse/JENKINS-(\\d+)\\]\\(JENKINS-(\\d+)\\)\\]/g',
           replace:
             '[https://issues.jenkins-ci.org/browse/JENKINS-$1](JENKINS-$1)'


### PR DESCRIPTION
In #185 we added a new `replacers` option, that had two separate sub-keys: `regex` and `search`. This simplifies the config down to a single `search` key that can handle both plain string values, and strings that look like a regular expression.

The `regex` key can no longer be used.