### PR TITLE
Fix branch matching for GitHub Actions

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,11 @@ module.exports = app => {
     })
     config['sort-direction'] = validateSortDirection(config['sort-direction'])
 
-    const branch = context.payload.ref.replace(/^refs\/heads\//, '')
+    // GitHub Actions merge payloads slightly differ, in that their ref points
+    // to the PR branch instead of refs/heads/master
+    const ref = process.env['GITHUB_REF'] || context.payload.ref
+
+    const branch = ref.replace(/^refs\/heads\//, '')
 
     if (!config.template) {
       log({ app, context, message: 'No valid config found' })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -32,13 +32,11 @@ describe('release-drafter', () => {
     nock('https://api.github.com')
       .post('/app/installations/179208/access_tokens')
       .reply(200, { token: 'test' })
-  })
 
-  beforeAll(() => {
-    // If we're running our actual test process inside a GitHub Action, we don't
-    // want all the GitHub Action conditional logic to be triggered. That's for
-    // *running* inside a GitHub Action, not for *testing* using GitHub Actions.
-    // So let's just delete them all when running tests.
+    // We have to delete all the GITHUB_* envs before every test, because if
+    // we're running the tests themselves inside a GitHub Actions container
+    // they'll mess with the tests, and also because we set some of them in
+    // tests and we don't want them to leak into other tests.
     Object.keys(process.env)
       .filter(key => key.match(/^GITHUB_/))
       .forEach(key => {


### PR DESCRIPTION
For some reason unbenkownst to me, Github Actions payload refs are different to the usual webhooks.

For example:

<img width="303" alt="image" src="https://user-images.githubusercontent.com/153/58739119-02bf8e80-844c-11e9-847f-0e36c1ac4825.png">

> 22:49:29.286Z  INFO probot: toolmantim/release-drafter: Ignoring push. renovate/semver-6.x is not one of: master

This changes it to use the `GITHUB_REF` environment variable.