### PR TITLE
Don't filter cross repository PRs

### DIFF
--- a/lib/commits.js
+++ b/lib/commits.js
@@ -93,10 +93,7 @@ module.exports.findCommitsWithAssociatedPullRequests = async ({
 
   const commits = _.get(data, [...dataPath, 'nodes'])
   const pullRequests = _.uniqBy(
-    _.filter(
-      _.flatten(commits.map(commit => commit.associatedPullRequests.nodes)),
-      pr => !pr.isCrossRepository
-    ),
+    _.flatten(commits.map(commit => commit.associatedPullRequests.nodes)),
     'number'
   )
 


### PR DESCRIPTION
I made a mistake in #224 because new PRs from me and @casz aren't showing up in the release notes draft. I will take another look at fixing this for real this week.